### PR TITLE
Refactor disk chunk store

### DIFF
--- a/sn/src/routing/core/chunk_records.rs
+++ b/sn/src/routing/core/chunk_records.rs
@@ -230,9 +230,9 @@ impl Core {
         if we_are_not_holder_anymore || new_adult_is_holder || lost_old_holder {
             info!("Republishing chunk at {:?}", address);
             trace!("We are not a holder anymore? {}, New Adult is Holder? {}, Lost Adult was holder? {}", we_are_not_holder_anymore, new_adult_is_holder, lost_old_holder);
-            let chunk = chunks.get_chunk(address).ok()?;
+            let chunk = chunks.get_chunk(address).await.ok()?;
             if we_are_not_holder_anymore {
-                if let Err(err) = chunks.remove_chunk(address) {
+                if let Err(err) = chunks.remove_chunk(address).await {
                     warn!("Error deleting chunk during republish: {:?}", err);
                 }
             }

--- a/sn/src/routing/core/chunk_store/chunk_disk_store.rs
+++ b/sn/src/routing/core/chunk_store/chunk_disk_store.rs
@@ -90,10 +90,6 @@ impl ChunkDiskStore {
     }
 
     pub(crate) async fn write_chunk(&self, data: &Chunk) -> Result<ChunkAddress> {
-        if !self.used_space.can_consume(data.value().len() as u64).await {
-            return Err(Error::NotEnoughSpace);
-        }
-
         let addr = data.address();
         let filepath = self.address_to_filepath(addr)?;
         if let Some(dirs) = filepath.parent() {

--- a/sn/src/routing/core/chunk_store/mod.rs
+++ b/sn/src/routing/core/chunk_store/mod.rs
@@ -44,15 +44,15 @@ impl ChunkStore {
         self.disk_store.list_all_chunk_addresses()
     }
 
-    pub(crate) fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
+    pub(crate) async fn remove_chunk(&self, address: &ChunkAddress) -> Result<()> {
         trace!("Removing chunk, {:?}", address);
-        self.disk_store.delete_chunk(address)
+        self.disk_store.delete_chunk(address).await
     }
 
-    pub(crate) fn get_chunk(&self, address: &ChunkAddress) -> Result<Chunk> {
+    pub(crate) async fn get_chunk(&self, address: &ChunkAddress) -> Result<Chunk> {
         debug!("Getting chunk {:?}", address);
 
-        match self.disk_store.read_chunk(address) {
+        match self.disk_store.read_chunk(address).await {
             Ok(res) => Ok(res),
             Err(error) => match error {
                 Error::Io(io_error) if io_error.kind() == ErrorKind::NotFound => {
@@ -64,9 +64,13 @@ impl ChunkStore {
     }
 
     // Read chunk from local store and return NodeQueryResponse
-    pub(crate) fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
+    pub(crate) async fn get(&self, address: &ChunkAddress) -> NodeQueryResponse {
         trace!("{:?}", LogMarker::ChunkQueryReceviedAtAdult);
-        NodeQueryResponse::GetChunk(self.get_chunk(address).map_err(convert_to_error_message))
+        NodeQueryResponse::GetChunk(
+            self.get_chunk(address)
+                .await
+                .map_err(convert_to_error_message),
+        )
     }
 
     /// Store a chunk in the local disk store

--- a/sn/src/routing/core/chunk_store/mod.rs
+++ b/sn/src/routing/core/chunk_store/mod.rs
@@ -88,7 +88,7 @@ impl ChunkStore {
         }
 
         trace!("{:?}", LogMarker::StoringChunk);
-        self.disk_store.write_chunk(data).await?;
+        let _addr = self.disk_store.write_chunk(data).await?;
         trace!("{:?}", LogMarker::StoredNewChunk);
 
         let last_recorded_level = { *self.last_recorded_level.read().await };

--- a/sn/src/routing/core/msg_handling/service_msgs.rs
+++ b/sn/src/routing/core/msg_handling/service_msgs.rs
@@ -171,7 +171,7 @@ impl Core {
         let mut commands = vec![];
 
         let msg = SystemMsg::NodeQueryResponse {
-            response: self.chunk_storage.get(address),
+            response: self.chunk_storage.get(address).await,
             correlation_id: msg_id,
             user,
         };


### PR DESCRIPTION
- Makes disk I/O aync.
- Removes repetitive code in tests.
- Removes checking if space available on every write.

### Making I/O async

There wasn't much spread of async, this code is like a leaf, and just above it everything is async (by now, very few places would not be, mostly CPU intensive things like e.g. self encryption).
So, it was all good to go async there.

## Repetitive code

Some code reuse. It also means however, that on the concurrent I/O test cases, we do not check if every chunk read matches the chunk that was written on that address. Instead that check is included in the first test case.
The concurrent I/O tests thereby test only that all chunks that were written, were also read.
I.e., the test if a chunk at an address actually is of same value as the chunk that was originally written to that address, is moved to the first test case.
If we want, we could modify/expand so that we also test that this holds for concurrent I/O as well.

## Space available check

Doing this for every write is immensely wasteful. 

There is just one time when it will be necessary, which is right after it is filled by the last chunk it an hold.
But as long as nodes truthfully report their used space (`StorageLevel`), then this will never occur, as we stop sending them chunks well before they are actually full.
(Later we can look at detecting that specific error, when we want to implement some way for Elders to act on it.)

Therefore, we can let the tokio writer return that error - when/if that ever occurs - which would be bubbled up and encapsulated in a generic error type.

